### PR TITLE
helm automatic roll deployment …

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -20,3 +20,7 @@
 .idea/
 *.tmproj
 .vscode/
+/CHANGELOG.md
+/README.md
+/.cr-release-packages/
+/docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.2] - 2020-09-09
+
+### Changed
+
+- Fix not working rolling update with helm upgrade. Add timestamp annotation in deployment config
+- Update .helmignore to reduce package size
+
 ## [1.10.1] - 2020-08-24
 
 ### Changed
@@ -53,4 +60,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.9.5]: https://github.com/DVPE-cloud/aws-helm-service-chart/tree/aws-helm-service-chart-1.9.5
 [1.10.0]: https://github.com/DVPE-cloud/aws-helm-service-chart/tree/aws-helm-service-chart-1.10.0
 [1.10.1]: https://github.com/DVPE-cloud/aws-helm-service-chart/tree/aws-helm-service-chart-1.10.1
+[1.10.2]: https://github.com/DVPE-cloud/aws-helm-service-chart/tree/aws-helm-service-chart-1.10.2
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1"
 description: Helm chart for default microservice projects
 name: aws-helm-service-chart
-version: 1.10.1
+version: 1.10.2

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -46,5 +46,14 @@ entries:
     urls:
       - https://github.com/DVPE-cloud/aws-helm-service-chart/releases/download/aws-helm-service-chart-1.10.1/aws-helm-service-chart-1.10.1.tgz
     version: 1.10.1
+  - apiVersion: v1
+    appVersion: "1.1"
+    created: "2020-09-08T13:27:46.161958+02:00"
+    description: Helm chart for default microservice projects
+    digest: aebf5baba24f6c850fb984a56557d10611bac5767773e4945ddedd1c9ba7da65
+    name: aws-helm-service-chart
+    urls:
+      - https://github.com/DVPE-cloud/aws-helm-service-chart/releases/download/aws-helm-service-chart-1.10.2/aws-helm-service-chart-1.10.2.tgz
+    version: 1.10.2
 
 generated: "2020-06-10T10:21:39.309742+02:00"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -15,8 +15,8 @@ spec:
     metadata:
       labels:
         app: {{ $serviceName }}
-      {{- if .Values.datadog.enabled }}
       annotations:
+      {{- if .Values.datadog.enabled }}
         ad.datadoghq.com/{{ $serviceName }}.check_names: '["{{ $serviceName }}"]'
         ad.datadoghq.com/{{ $serviceName }}.init_configs: '[{}]'
         ad.datadoghq.com/{{ $serviceName }}.logs: '[{"source":"{{ .Values.datadog.source.service }}", "service":"{{ $serviceName }}" }]'
@@ -28,6 +28,7 @@ spec:
         ad.datadoghq.com/{{ $serviceName }}-auth-sidecar.tags: '{"team": "DVPE"}'
         {{- end }}
       {{- end }}
+      helm/deployment-timestamp: {{ now | unixEpoch }}
     spec:
       imagePullSecrets:
         - name: aws-ecr-secret


### PR DESCRIPTION
Added new annotation field in deployment.
This change will enable automatic roll deployments on every helm upgrade.
The annotation field helm/deployment-timestamp gets filled with current timestamp and let restart the pods on helm upgrade.

Signed-off-by: Cliff Dornig <cliff.dornig@iteratec.com>